### PR TITLE
Fix Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ module.exports = function getPlugin(S) {
           // 2. Generate wrapped handler code
           return codeTemplate({
             orig_handler_path: `./${savedHandlerFilename}`,
-            wrapper_path: relativeWrapperPath,
+            wrapper_path: relativeWrapperPath.replace(/\\/g, '/'), // Support Windows env
             handler_name: handlerFunction,
           });
         })


### PR DESCRIPTION
On Windows this plugin generates `_serverless_handler.js` content as

```javascript
/* Automatically generated by the serverless-wrapper-plugin */

const _handler = require('./_serverless_handler__orig__.js').handler;
const _wrapper = require('..\\..\\lib\\wrapper\\index.js');

module.exports.handler = function (event, context) {
  return _wrapper(_handler, event, context);
}
```

This patch ensures that on Windows internal require path is generated with posix separators and not windows (those are not supported by webpack, and in general should never be used in require's).

So in result we get expected:

```javascript
/* Automatically generated by the serverless-wrapper-plugin */

const _handler = require('./_serverless_handler__orig__.js').handler;
const _wrapper = require('../../lib/wrapper/index.js');

module.exports.handler = function (event, context) {
  return _wrapper(_handler, event, context);
}
```

Tested both on Windows (fixed) and *nix (things work as they worked)
