### PR TITLE
Fix handler resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ module.exports = function getPlugin(S) {
 
       // Get the name of the handler function (within the handler module)
       const handler = func.handler;
-      const handlerFunction = handler.split('.').shift();
+      const handlerFunction = handler.split('.').pop();
 
       // Information about the serverless framework version of the handler
       // [NOTE: the version in the package directory (pathDist)]


### PR DESCRIPTION
Handler is defined as e.g. `handler.handler` where first token states name of a file and second name of the property on which lambda is exposed.

So far it was first token that was used to resolve name of the property. That worked for us (by chance) ok in `mass-backed` as long as we relied on `handler.handler`, but it broke case where we switched to `index.handler`.
