### PR TITLE
Support functionRun command

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,9 +36,9 @@ module.exports = function getPlugin(S) {
       S.addHook(this.post.bind(this), {
         action: 'functionRun',
         event: 'post',
-			});
+      });
 
-			return Promise.resolve();
+      return Promise.resolve();
     }
 
     // Pre event
@@ -103,17 +103,17 @@ module.exports = function getPlugin(S) {
         // If we do have a wrapper, we need to clean up intermediate files
       else if (funcConfig && funcConfig.wrapper && funcConfig.wrapper.path ||
                  projConfig && projConfig.wrapper && projConfig.wrapper.path) {
-				const pathSource = path.dirname(func.getFilePath());
-				const isLocalRun = !evt.options.pathDist;
-				const savedHandlerPath = this._getSavedHandlerPath(func, pathSource);
+        const pathSource = path.dirname(func.getFilePath());
+        const isLocalRun = !evt.options.pathDist;
+        const savedHandlerPath = this._getSavedHandlerPath(func, pathSource);
 				
-				const action = isLocalRun
-					? fs.moveAsync(
-							savedHandlerPath,
-							this._getServerlessHandlerPath(func.handler, pathSource),
-							{ clobber: true }
-						)
-					: fs.unlinkAsync(savedHandlerPath);
+        const action = isLocalRun
+          ? fs.moveAsync(
+              savedHandlerPath,
+              this._getServerlessHandlerPath(func.handler, pathSource),
+              { clobber: true }
+            )
+          : fs.unlinkAsync(savedHandlerPath);
 
         return action.then(() => evt);
       }
@@ -127,8 +127,8 @@ module.exports = function getPlugin(S) {
 
     _wrapHandler(project, func, evt, wrapperPath) {
       const pathSource = path.dirname(func.getFilePath());
-			const pathDist = evt.options.pathDist;
-			const isLocalRun = !pathDist;
+      const pathDist = evt.options.pathDist;
+      const isLocalRun = !pathDist;
 
       // Get the name of the handler function (within the handler module)
       const handler = func.handler;
@@ -137,9 +137,9 @@ module.exports = function getPlugin(S) {
       // Information about the serverless framework version of the handler
       // [NOTE: the version in the package directory (pathDist)]
       const serverlessHandlerPath = this._getServerlessHandlerPath(
-				isLocalRun ? handler : func.getHandler(),
-				isLocalRun ? pathSource : pathDist
-			);
+        isLocalRun ? handler : func.getHandler(),
+        isLocalRun ? pathSource : pathDist
+      );
 
       // The new wrapped handler.
       // This will take the place of the original serverless framework handler

--- a/index.js
+++ b/index.js
@@ -18,22 +18,22 @@ module.exports = function getPlugin(S) {
     }
 
     registerHooks() {
-      S.addHook(this.pre.bind(this), {
+      S.addHook(this.preAction.bind(this), {
         action: 'codeDeployLambda',
         event: 'pre',
       });
 
-      S.addHook(this.post.bind(this), {
+      S.addHook(this.postAction.bind(this), {
         action: 'codeDeployLambda',
         event: 'post',
       });
 
-      S.addHook(this.pre.bind(this), {
+      S.addHook(this.preAction.bind(this), {
         action: 'functionRun',
         event: 'pre',
       });
 
-      S.addHook(this.post.bind(this), {
+      S.addHook(this.postAction.bind(this), {
         action: 'functionRun',
         event: 'post',
       });
@@ -48,7 +48,7 @@ module.exports = function getPlugin(S) {
      * Intercept the codeDeployLammbda hook and wrap the serverless handler
      * function in the configured wrapper function.
      */
-    pre(evt) {
+    preAction(evt) {
       // Validate: Check Serverless version
       if (parseInt(S._version.split('.')[1], 10) < 5) {
         SCli.log('WARNING: This version of the Serverless Wrapper Plugin ' +
@@ -88,7 +88,7 @@ module.exports = function getPlugin(S) {
      * Once the codeDeployLambda operation has completed,
      * clean up any intermediate files
      */
-    post(evt) {
+    postAction(evt) {
       // Get function
       const project = S.getProject();
       const func = project.getFunction(evt.options.name);

--- a/index.js
+++ b/index.js
@@ -18,12 +18,12 @@ module.exports = function getPlugin(S) {
     }
 
     registerHooks() {
-      S.addHook(this.onCodeDeployPre.bind(this), {
+      S.addHook(this.pre.bind(this), {
         action: 'codeDeployLambda',
         event: 'pre',
       });
 
-      S.addHook(this.onCodeDeployPost.bind(this), {
+      S.addHook(this.post.bind(this), {
         action: 'codeDeployLambda',
         event: 'post',
       });
@@ -38,7 +38,7 @@ module.exports = function getPlugin(S) {
      * Intercept the codeDeployLammbda hook and wrap the serverless handler
      * function in the configured wrapper function.
      */
-    onCodeDeployPre(evt) {
+    pre(evt) {
       // Validate: Check Serverless version
       if (parseInt(S._version.split('.')[1], 10) < 5) {
         SCli.log('WARNING: This version of the Serverless Wrapper Plugin ' +
@@ -78,7 +78,7 @@ module.exports = function getPlugin(S) {
      * Once the codeDeployLambda operation has completed,
      * clean up any intermediate files
      */
-    onCodeDeployPost(evt) {
+    post(evt) {
       // Get function
       const project = S.getProject();
       const func = project.getFunction(evt.options.name);


### PR DESCRIPTION
Lambdas are not auto wrapped with `sls function fun`. This patch fixes that.

Not having that is an issue for [maas-backend](https://github.com/maasglobal/maas-backend/), as since we [moved lambda input/output logs to wrapper](https://github.com/maasglobal/maas-backend/pull/1636) they're not longer output in local run.
SLS also doesn't display outcome on its own, as we rely on custom [local runtime plugin](https://github.com/maasglobal/serverless-plugin-local-runtime) which runs runs lambdas as external processes.

--- 

Tested both local function run, and function deployment to confirm it was not affected.